### PR TITLE
Correct Starck/Snowtrooper defaults.

### DIFF
--- a/src/constants/characters.js
+++ b/src/constants/characters.js
@@ -1736,7 +1736,9 @@ let charactersArray = [
     DamageType.physical,
     new OptimizationPlan('PvP', 0, 0, 0, 100, 0, 0, 50, 0, 25, 0, 0, 0, 0),
     {
-      'PvP': new OptimizationPlan('PvP', 0, 0, 0, 100, 0, 0, 50, 0, 25, 0, 0, 0, 0)
+      'PvP': new OptimizationPlan('PvP', 0, 0, 0, 100, 0, 0, 50, 0, 25, 0, 0, 0, 0),
+      'Fast PvP': new OptimizationPlan('PvP', 0, 0, 100, 50, 0, 0, 50, 0, 100, 0, 0, 0, 0),
+      'Fast PvE': new OptimizationPlan('PvE', 0, 0, 80, 50, 0, 0, 25, 0, 100, 0, 0, 0, 0)
     },
     ['Dark Side', 'Empire', 'Imperial Trooper', 'Attacker'],
     ['Troopers'],

--- a/src/constants/characters.js
+++ b/src/constants/characters.js
@@ -373,9 +373,9 @@ let charactersArray = [
     'Colonel Starck',
     'COLONELSTARCK',
     DamageType.physical,
-    optimizationStrategy["Speed, Crit, Physical Damage, Potency"].rename('PvP'),
+    new OptimizationPlan('PvP', 0, 0, 100, 10, 5, 0, 5, 0, 5, 0, 0, 0, 0),
     {
-      'PvP': optimizationStrategy["Speed, Crit, Physical Damage, Potency"].rename('PvP')
+      'PvP': new OptimizationPlan('PvP', 0, 0, 100, 10, 5, 0, 5, 0, 5, 0, 0, 0, 0)
     },
     ['Dark Side', 'Empire', 'Imperial Trooper', 'Support'],
     ['Tony Stark', 'Troopers'],
@@ -1734,10 +1734,9 @@ let charactersArray = [
     'Snowtrooper',
     'SNOWTROOPER',
     DamageType.physical,
-    new OptimizationPlan('PvP', 0, 0, 100, 50, 0, 0, 50, 0, 100, 0, 0, 0, 0),
+    new OptimizationPlan('PvP', 0, 0, 0, 100, 0, 0, 50, 0, 25, 0, 0, 0, 0),
     {
-      'PvP': new OptimizationPlan('PvP', 0, 0, 100, 50, 0, 0, 50, 0, 100, 0, 0, 0, 0),
-      'PvE': new OptimizationPlan('PvE', 0, 0, 80, 50, 0, 0, 25, 0, 100, 0, 0, 0, 0)
+      'PvP': new OptimizationPlan('PvP', 0, 0, 0, 100, 0, 0, 50, 0, 25, 0, 0, 0, 0)
     },
     ['Dark Side', 'Empire', 'Imperial Trooper', 'Attacker'],
     ['Troopers'],


### PR DESCRIPTION
Fixing two modding suggestion issues, one minor and one extremely large. Starck default leaning too far away from speed. Snowtrooper default asking for any speed is incorrect as the trooper uniques power his turns forward, optimal is 60% CC, 216+% CD with as much offense as can fit with little to no speed added.