### PR TITLE
Add a sort order of "Offense Score" for sorting by danger

### DIFF
--- a/src/components/ModFilter/ModFilter.js
+++ b/src/components/ModFilter/ModFilter.js
@@ -404,6 +404,7 @@ class ModFilter extends React.PureComponent {
         <select name={'sort-option'} defaultValue={this.props.filter.sort}>
           <option value={''}>default</option>
           <option value={'rolls'}># of Stat Upgrades</option>
+          <option value={'offenseScore'}>Offense Score</option>
           <option value={'character'}>Character</option>
           {sortOptions}
         </select>

--- a/src/containers/ExploreView/ExploreView.js
+++ b/src/containers/ExploreView/ExploreView.js
@@ -9,6 +9,8 @@ import './ExploreView.css';
 import {connect} from "react-redux";
 import Sidebar from "../../components/Sidebar/Sidebar";
 
+import offenseScore from "../../utils/subjectiveScoring";
+
 class ExploreView extends React.PureComponent {
   render() {
     const modElements = this.props.displayedMods.map(mod => {
@@ -73,6 +75,14 @@ const getFilteredMods = memoize(
         filteredMods = filteredMods.sort((left, right) => {
           const leftValue = left.secondaryStats.reduce((acc, stat) => acc + stat.rolls, 0);
           const rightValue = right.secondaryStats.reduce((acc, stat) => acc + stat.rolls, 0);
+
+          return rightValue - leftValue;
+        });
+        break;
+      case 'offenseScore':
+        filteredMods = filteredMods.sort((left, right) => {
+          const leftValue = offenseScore(left);
+          const rightValue = offenseScore(right);
 
           return rightValue - leftValue;
         });

--- a/src/utils/subjectiveScoring.js
+++ b/src/utils/subjectiveScoring.js
@@ -1,0 +1,61 @@
+
+/**
+ * Return a score (suitable for sorting) of the offensive power of a mod.  This is a subjective score
+ * based on the relative value of different types of sets and stats.  It is along the lines of the
+ * evalutation here:
+ *
+ * https://gaming-fans.com/swgoh-101/swgoh-101-comprehensive-mod-guide/swgoh-101-mod-guide-choose-good-mods/
+ *
+ * @param mod Mod
+ */
+export default function offenseScore(mod) {
+	var score = 0;
+	
+	// weights for the set (mod type), primary attribute and secondary attributes
+	let setScore = {
+		'critchance' : 30,
+		'critdamage' : 30,
+		'offense' : 30,
+		'potency' : 25,
+		'defense' : 10,
+		'health' : 10,
+		'speed' : 5,
+		'tenacity' : 0,
+	};
+	
+	let primaryScore = {
+		'Speed' : 50,
+		'Critical Damage %' : 40,
+		'Critical Chance %' : 30,
+		'Offense %' : 25,
+		'Defense %' : 10,
+		'Health %' : 10,
+		'Protection %' : -20,
+		'Accuracy' : -60,
+		'Tenacity %' : -60,
+	};
+	
+	let secondaryScore = {
+		'Speed' : 6,
+		'Offense' : 5,
+		'Critical Chance %' : 2,
+		'Defense' : 1,
+		'Offense %' : 1,
+		'Potency %' : 1,
+		'Health' : 1,
+		'Defense %' : 0,
+		'Health %' : 0,
+		'Protection' : 0,
+		'Protection %' : 0,
+		'Tenacity %' : 0,
+	};
+	
+	// combine them -- the weight is roughly 30 / 40 / 100
+	score += setScore[mod.set.name];	
+	score += primaryScore[mod.primaryStat.type];
+	
+	// secondaries are weighted by the square of the number of rolls on that stat -- 4 speed rolls is pretty valuable
+	score += mod.secondaryStats.reduce((acc, stat) => acc + (stat.rolls * stat.rolls) * secondaryScore[stat.type], 0)
+	
+	return score;
+};


### PR DESCRIPTION
Add a sort order of "Offense Score" that scores mods with more and better offense stats higher.

Finding a good offensive mod can be difficult.  You might want speed, but then do you want offense?  Critical damage?  What about the mod set?  If you just want to see the most dangerous mods you have, this will apply a subjective score to rank them.  Mods with more offensive capabilities rank higher than mods with less.  You can combine this with the other filters to find, e.g. all blue mods that would be good candidates for slicing.

A similar technique could be used for defensive mods.