### PR TITLE
Fix armor targets

### DIFF
--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -709,6 +709,7 @@ function modSetSatisfiesCharacterRestrictions(modSet, character, target) {
  * @param target {OptimizationPlan}
  */
 function getMissedGoals(modSet, character, goalStats, target) {
+  console.log("goalstats", goalStats);
   const missedStats = goalStats.map(goalStat => {
     const characterValue = getStatValueForCharacterWithMods(modSet, character, goalStat.stat, target);
 
@@ -810,7 +811,14 @@ function getStatValueForCharacterWithMods(modSet, character, stat, target) {
     setStat.displayType === stat ? setValueSum + setStat.value : setValueSum
     , 0);
 
-  return baseValue + setValue;
+    let returnValue = baseValue + setValue;
+
+    // Change target stat to a percentage for Armor and Resistance
+    // so Reo'Ris shuts up about it in the Discord.
+    if (['armor', 'resistance'].includes(statProperty)) {
+      returnValue = 100 * returnValue / (character.playerValues.level * 7.5 + returnValue);
+    }
+  return returnValue;
 }
 
 /**

--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -709,7 +709,6 @@ function modSetSatisfiesCharacterRestrictions(modSet, character, target) {
  * @param target {OptimizationPlan}
  */
 function getMissedGoals(modSet, character, goalStats, target) {
-  console.log("goalstats", goalStats);
   const missedStats = goalStats.map(goalStat => {
     const characterValue = getStatValueForCharacterWithMods(modSet, character, goalStat.stat, target);
 


### PR DESCRIPTION
Fixes a problem where users cannot type an "Armor" or "Resistance" target that matches the displayed values for "Armor" or "Resistance".

This is due to the fact that when building the list of target stats, the raw value for Armor and Resistance is stored in the target stat and compared to the target value.

It also fixes the error messages that appear when a target stat is not met so that they display the calculated values, not the raw values, for the stats.

### Before
![image](https://user-images.githubusercontent.com/11711132/112250033-7e836e80-8ca4-11eb-93fb-7aabc31f2b0e.png)

### After
![image](https://user-images.githubusercontent.com/11711132/112250288-d5894380-8ca4-11eb-9348-bd7b113fb659.png)
