### PR TITLE
Add missing stats

### DIFF
--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -709,6 +709,7 @@ function modSetSatisfiesCharacterRestrictions(modSet, character, target) {
  * @param target {OptimizationPlan}
  */
 function getMissedGoals(modSet, character, goalStats, target) {
+  console.log("goalstats", goalStats);
   const missedStats = goalStats.map(goalStat => {
     const characterValue = getStatValueForCharacterWithMods(modSet, character, goalStat.stat, target);
 
@@ -810,7 +811,14 @@ function getStatValueForCharacterWithMods(modSet, character, stat, target) {
     setStat.displayType === stat ? setValueSum + setStat.value : setValueSum
     , 0);
 
-  return baseValue + setValue;
+    let returnValue = baseValue + setValue;
+
+    // Change target stat to a percentage for Armor and Resistance
+    // so Reo'Ris shuts up about it in the Discord.
+    if (['armor', 'resistance'].includes(statProperty)) {
+      returnValue = 100 * returnValue / (character.playerValues.level * 7.5 + returnValue);
+    }
+  return returnValue;
 }
 
 /**

--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -709,7 +709,6 @@ function modSetSatisfiesCharacterRestrictions(modSet, character, target) {
  * @param target {OptimizationPlan}
  */
 function getMissedGoals(modSet, character, goalStats, target) {
-  console.log("goalstats", goalStats);
   const missedStats = goalStats.map(goalStat => {
     const characterValue = getStatValueForCharacterWithMods(modSet, character, goalStat.stat, target);
 

--- a/src/domain/CharacterStats.js
+++ b/src/domain/CharacterStats.js
@@ -30,7 +30,10 @@ class CharacterStats {
     armor,
     specDmg,
     specCritRating,
-    resistance
+    resistance,
+    critDmg,
+    critAvoid,
+    accuracy
   ) {
     // General stats
     this.health = health;
@@ -38,6 +41,9 @@ class CharacterStats {
     this.speed = speed;
     this.potency = potency * 100;
     this.tenacity = tenacity * 100;
+    this.critDmg = critDmg * 100;
+    this.critAvoid = critAvoid / 24;
+    this.accuracy = accuracy / 12;
 
     // Physical stats
     this.physDmg = physDmg;
@@ -53,10 +59,6 @@ class CharacterStats {
     this.physCritChance = physCritRating / 24 + 10;
     this.specCritChance = specCritRating / 24 + 10;
 
-    // Constant stats
-    this.critDmg = 150;
-    this.accuracy = 0;
-    this.critAvoid = 0;
   }
 
   /**
@@ -104,7 +106,10 @@ class CharacterStats {
       this.armor + that.armor,
       this.specDmg + that.specDmg,
       this.specCritRating + that.specCritRating,
-      this.resistance + that.resistance
+      this.resistance + that.resistance,
+      (this.critDmg + that.critDmg) / 100,
+      (this.critAvoid + that.critAvoid) * 24,
+      (this.accuracy + that.accuracy) * 12
     )
   }
 
@@ -125,7 +130,10 @@ class CharacterStats {
         baseStatsJson.armor,
         baseStatsJson.specDmg,
         baseStatsJson.specCritRating,
-        baseStatsJson.resistance
+        baseStatsJson.resistance,
+        baseStatsJson.critDmg / 100,
+        baseStatsJson.critAvoid * 24,
+        baseStatsJson.accuracy * 12
       );
     } else {
       return null;
@@ -133,7 +141,7 @@ class CharacterStats {
   }
 }
 
-const NullCharacterStats = new CharacterStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+const NullCharacterStats = new CharacterStats(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 Object.freeze(NullCharacterStats);
 
 export default CharacterStats;

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -257,7 +257,6 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
         const characterStats = fetchData.characterStats.reduce(
           (characters, unit) => {
             const stats = unit.stats;
-if (unit.defId ==='JEDIKNIGHTLUKE') {console.log(stats);}
             const baseStats = stats.base ?
               new CharacterStats(
                 stats.base['Health'] || 0,

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -232,7 +232,7 @@ function fetchCharacterStats(characters = null) {
           }
         }));
 
-        swgohStatCalc.calcRosterStats(characterData, { widhoutModCalc: true, language: eng_us });
+        swgohStatCalc.calcRosterStats(characterData, { withoutModCalc: true, language: eng_us });
 
         return characterData;
       })
@@ -257,7 +257,7 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
         const characterStats = fetchData.characterStats.reduce(
           (characters, unit) => {
             const stats = unit.stats;
-
+if (unit.defId ==='JEDIKNIGHTLUKE') {console.log(stats);}
             const baseStats = stats.base ?
               new CharacterStats(
                 stats.base['Health'] || 0,
@@ -270,7 +270,10 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
                 stats.base['Armor'] || 0,
                 stats.base['Special Damage'] || 0,
                 stats.base['Special Critical Chance'] || 0,
-                stats.base['Resistance'] || 0
+                stats.base['Resistance'] || 0,
+                stats.base['Critical Damage'] || 0,
+                stats.base['Physical Critical Avoidance'] || 0,
+                stats.base['Physical Accuracy'] || 0
               ) :
               NullCharacterStats;
 
@@ -288,7 +291,10 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
                 stats.gear['Armor'] || 0,
                 stats.gear['Special Damage'] || 0,
                 stats.gear['Special Critical Chance'] || 0,
-                stats.gear['Resistance'] || 0
+                stats.gear['Resistance'] || 0,
+                stats.gear['Critical Damage'] || 0,
+                stats.gear['Physical Critical Avoidance'] || 0,
+                stats.gear['Physical Accuracy'] || 0
               );
               equippedStats = baseStats.plus(gearStats);
             }


### PR DESCRIPTION
This PR fixes issues with incorrect base stats for CD, CA and Accuracy on toons that derive boosted base stats from relic levels.

Affected toons I have noticed:
Han Solo (CD)
General Grievous (CD)
Old Daka (CA)
Jedi Knight Luke Skywalker (Accuracy)

These and other toons will now calculate the correct base stats on refresh from HotUtils or SWGOH.Help. Will not affect saved data in json export files as these values are only calculated on import from the game.

![image](https://user-images.githubusercontent.com/11711132/112266099-4a697700-8cbf-11eb-9d6e-3370fdfe25aa.png)
