### PR TITLE
H plus p stat

### DIFF
--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -795,22 +795,37 @@ function modSetFulfillsTargetStatRestriction(modSet, character, target) {
  * @param target {OptimizationPlan}
  */
 function getStatValueForCharacterWithMods(modSet, character, stat, target) {
-  if (statTypeMap[stat].length > 1) {
+  if (statTypeMap[stat]?.length > 1) {
     throw new Error(
       "Trying to set an ambiguous target stat. Offense, Crit Chance, etc. need to be broken into physical or special."
     );
   }
-  const statProperty = statTypeMap[stat][0];
-  const baseValue = character.playerValues.equippedStats[statProperty];
+  if (stat === "Health+Protection")
+  {
+    const healthProperty = statTypeMap["Health"][0];
+    const protProperty = statTypeMap["Protection"][0];
+    const baseValue = character.playerValues.equippedStats[healthProperty] + character.playerValues.equippedStats[protProperty];
 
-  const setStats = getFlatStatsFromModSet(modSet, character, target);
+    const setStats = getFlatStatsFromModSet(modSet, character, target);
+  
+    const setValue = setStats.reduce((setValueSum, setStat) =>
+      // Check to see if the stat is health or protection. If it is, add its value to the total.
+      setStat.displayType === "Health" || setStat.displayType === "Protection" ? setValueSum + setStat.value : setValueSum
+        , 0);
+    return baseValue + setValue; 
+  }
+  else{
+    const statProperty = statTypeMap[stat][0];
+    const baseValue = character.playerValues.equippedStats[statProperty];
 
-  const setValue = setStats.reduce((setValueSum, setStat) =>
-    // Check to see if the stat is the target stat. If it is, add its value to the total.
-    setStat.displayType === stat ? setValueSum + setStat.value : setValueSum
-    , 0);
-
-  return baseValue + setValue;
+    const setStats = getFlatStatsFromModSet(modSet, character, target);
+  
+    const setValue = setStats.reduce((setValueSum, setStat) =>
+      // Check to see if the stat is the target stat. If it is, add its value to the total.
+      setStat.displayType === stat ? setValueSum + setStat.value : setValueSum
+        , 0);
+    return baseValue + setValue;
+  }
 }
 
 /**
@@ -1693,14 +1708,22 @@ function getStatValuesForCharacter(character, stats) {
   const characterValues = {};
   stats.forEach(stat => {
     const characterStatProperties = statTypeMap[stat];
-    if (1 < characterStatProperties.length) {
+    if (1 < characterStatProperties?.length) {
       throw new Error(
         "Trying to set an ambiguous target stat. Offense, Crit Chance, etc. need to be broken into physical or special."
       );
     }
-
-    characterValues[stat] =
-      character.playerValues.equippedStats[characterStatProperties[0]] || 0;
+    if (stat === "Health+Protection")
+    {
+      throw new Error(
+        "Cannot optimize Health+Protection. Use as Report Only."
+      );
+    }
+    else
+    {
+      characterValues[stat] =
+        character.playerValues.equippedStats[characterStatProperties[0]] || 0;
+    }
   })
 
   return characterValues;

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -272,6 +272,7 @@ class CharacterEditForm extends PureComponent {
     const possibleTargetStats = [
       'Health',
       'Protection',
+      'Health+Protection',
       'Speed',
       'Critical Damage',
       'Potency',


### PR DESCRIPTION
Adds a "Report Only" Health+Protection stat to the target stats in the character editor.

Many guilds specify target stats for toons with H+P values (combined Health and Protection) but GI did not support this scenario. With this change, GI can do Health+Protection target stats. Only "Report Only" stats are supported. Trying to "Optimize" will result in an error message (see below.)

I would like to either implement Optimize or (preferably) disable the optimize option for this stat. Happy to take any guidance on approaches for this as the error message is a bit ugly.

![image](https://user-images.githubusercontent.com/11711132/112319333-afda5980-8cf9-11eb-9ece-d3f6357f5ce4.png)

Error message:
![image](https://user-images.githubusercontent.com/11711132/112319384-bc5eb200-8cf9-11eb-8319-d451db8e2218.png)
