### PR TITLE
Incremental optimization

### DIFF
--- a/public/workers/optimizer.js
+++ b/public/workers/optimizer.js
@@ -63,7 +63,6 @@ self.onmessage = function (message) {
 
         lastRun.characters = lastRunCharacters;
       }
-
       lastRun.modAssignments = profile.modAssignments;
 
       lastRun.selectedCharacters = lastRun.selectedCharacters instanceof Array ?
@@ -1190,7 +1189,8 @@ function optimizeMods(availableMods, characters, order, globalSettings, previous
       previousCharacter.optimizerSettings &&
       character.optimizerSettings.minimumModDots === previousCharacter.optimizerSettings.minimumModDots &&
       character.optimizerSettings.sliceMods === previousCharacter.optimizerSettings.sliceMods &&
-      character.optimizerSettings.isLocked === previousCharacter.optimizerSettings.isLocked
+      character.optimizerSettings.isLocked === previousCharacter.optimizerSettings.isLocked &&
+      previousRun.modAssignments[index]
     ) {
       const assignedMods = previousRun.modAssignments[index].assignedMods;
       const messages = previousRun.modAssignments[index].messages;

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -194,7 +194,7 @@ class CharacterEditForm extends React.Component {
           </div>
             {'basic' === this.props.editMode && this.basicForm(target)}
             {'advanced' === this.props.editMode && this.advancedForm(target)}
-            {this.targets(this.props.modAssignments.filter(x => x && x.id && x.id === character.baseID)[0]?.missedGoals)}
+            {this.missedGoalsSection(this.props.modAssignments[this.props.characterIndex])}
           </div>
         </div>
       </div>
@@ -657,7 +657,36 @@ class CharacterEditForm extends React.Component {
     </div>;
   }
 
-  targets (missedGoals) {
+  missedGoalsSection (modAssignments) {
+    const rerunButton = (
+      <div className={'form-footer'}>
+        <button type={'button'} onClick={() => this.runIncrementalCalc()}>Incremental Run</button>
+      </div>
+    )
+    
+    if (modAssignments === null)
+    {
+      return(
+        <div id={'missed-form'}>
+          <div className={'form-row'}>
+            <label>No optimiziation history yet</label>
+          </div>
+        {rerunButton}
+      </div>
+      );
+    }
+    const missedGoals = modAssignments.missedGoals;
+    if (missedGoals.length === 0)
+    {
+      return(
+        <div id={'missed-form'}>
+          <div className={'form-row'}>
+            <label>All targets were met last run!</label>
+          </div>
+        {rerunButton}
+      </div>
+      );
+    }
     const targetStatRows =  missedGoals && missedGoals.map((missedGoal, index) =>
     <div className={'form-row'} key={index}>
       <label>{missedGoal[0].stat}</label>
@@ -666,11 +695,7 @@ class CharacterEditForm extends React.Component {
       <label>{missedGoal[1]}</label>
       </div>
     );
-    const rerunButton = (
-      <div className={'form-footer'}>
-        <button type={'button'} onClick={() => this.runCalc()}>Save and Run</button>
-      </div>
-    )
+
     return (
       <div id={'missed-form'}>
         {targetStatRows}
@@ -679,7 +704,7 @@ class CharacterEditForm extends React.Component {
     );
   }
 
-  runCalc() {
+  runIncrementalCalc() {
     this.saveTarget(false);
     this.props.optimizeMods();
   }

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -658,7 +658,6 @@ class CharacterEditForm extends React.Component {
   }
 
   targets (missedGoals) {
-    if (!missedGoals) return;
     const targetStatRows =  missedGoals && missedGoals.map((missedGoal, index) =>
     <div className={'form-row'} key={index}>
       <label>{missedGoal[0].stat}</label>
@@ -675,14 +674,13 @@ class CharacterEditForm extends React.Component {
     return (
       <div id={'missed-form'}>
         {targetStatRows}
-        {missedGoals.length>0?rerunButton:""}
+        {rerunButton}
       </div>
     );
   }
 
   runCalc() {
     this.saveTarget(false);
-    console.log("Running target again");
     this.props.optimizeMods();
   }
 

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -687,12 +687,12 @@ class CharacterEditForm extends React.Component {
       </div>
       );
     }
-    const targetStatRows =  missedGoals && missedGoals.map((missedGoal, index) =>
+    const targetStatRows =  missedGoals && missedGoals.map(([targetStat, resultValue], index) =>
     <div className={'form-row'} key={index}>
-      <label>{missedGoal[0].stat}</label>
-      <label>({missedGoal[0].minimum})-({missedGoal[0].maximum})</label>
-      <label>{missedGoal[0].minimum > missedGoal[1] ? " ↓ ":" ↑ "}</label>
-      <label>{missedGoal[1]}</label>
+      <label>{targetStat.stat}</label>
+      <label>({targetStat.minimum})-({targetStat.maximum})</label>
+      <label>{targetStat.minimum > resultValue ? " ↓ ":" ↑ "}</label>
+      <label>{resultValue}</label>
       </div>
     );
 

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -687,7 +687,7 @@ class CharacterEditForm extends React.Component {
       </div>
       );
     }
-    const targetStatRows =  missedGoals && missedGoals.map(([targetStat, resultValue], index) =>
+    const targetStatRows =  missedGoals.map(([targetStat, resultValue], index) =>
     <div className={'form-row'} key={index}>
       <label>{targetStat.stat}</label>
       <label>({targetStat.minimum})-({targetStat.maximum})</label>

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -194,7 +194,7 @@ class CharacterEditForm extends React.Component {
           </div>
             {'basic' === this.props.editMode && this.basicForm(target)}
             {'advanced' === this.props.editMode && this.advancedForm(target)}
-            {this.missedGoalsSection(this.props.modAssignments[this.props.characterIndex])}
+            {this.missedGoalsSection(character.baseID === this.props.modAssignments[this.props.characterIndex]?.id ? this.props.modAssignments[this.props.characterIndex] : null)}
           </div>
         </div>
       </div>
@@ -669,7 +669,7 @@ class CharacterEditForm extends React.Component {
       return(
         <div id={'missed-form'}>
           <div className={'form-row'}>
-            <label>No optimiziation history yet</label>
+            <label>No optimization history yet</label>
           </div>
         {rerunButton}
       </div>
@@ -681,7 +681,7 @@ class CharacterEditForm extends React.Component {
       return(
         <div id={'missed-form'}>
           <div className={'form-row'}>
-            <label>All targets were met last run!</label>
+            <label>All targets met!</label>
           </div>
         {rerunButton}
       </div>

--- a/src/containers/CharacterEditForm/CharacterEditForm.js
+++ b/src/containers/CharacterEditForm/CharacterEditForm.js
@@ -664,7 +664,7 @@ class CharacterEditForm extends React.Component {
       </div>
     )
     
-    if (modAssignments === null)
+    if (modAssignments === undefined || modAssignments === null)
     {
       return(
         <div id={'missed-form'}>

--- a/src/containers/CharacterEditView/CharacterEditView.js
+++ b/src/containers/CharacterEditView/CharacterEditView.js
@@ -286,6 +286,9 @@ class CharacterEditView extends PureComponent {
       <button
         type={'button'}
         onClick={() => {
+          // TODO: Need to reset stopAt here, since by pressing this button we don't want incremental optimization
+          // this.props.profile.stopAt = "";
+
           const selectedTargets = this.props.selectedCharacters.map(({ target }) => target);
           const hasTargetStats = selectedTargets.some(target => target.targetStats &&
             target.targetStats.filter(targetStat => targetStat.optimizeForTarget).length)
@@ -905,7 +908,8 @@ const mapStateToProps = (state) => {
     selectedCharacters: profile.selectedCharacters,
     lastSelectedCharacter: profile.selectedCharacters.length - 1,
     showReviewButton: profile.modAssignments && Object.keys(profile.modAssignments).length,
-    characterTemplates: Object.keys(state.characterTemplates)
+    characterTemplates: Object.keys(state.characterTemplates),
+    stopAt: profile.stopAt,
   };
 };
 

--- a/src/containers/CharacterEditView/CharacterEditView.js
+++ b/src/containers/CharacterEditView/CharacterEditView.js
@@ -28,7 +28,8 @@ import {
   updateLockUnselectedCharacters,
   updateModChangeThreshold,
   updateForceCompleteModSets,
-  applyTemplateTargets
+  applyTemplateTargets,
+  resetIncrementalIndex
 } from "../../state/actions/characterEdit";
 import { changeOptimizerView, updateModListFilter } from "../../state/actions/review";
 import { optimizeMods } from "../../state/actions/optimize";
@@ -286,7 +287,7 @@ class CharacterEditView extends PureComponent {
       <button
         type={'button'}
         onClick={() => {
-
+          this.props.resetIncrementalIndex();
           const selectedTargets = this.props.selectedCharacters.map(({ target }) => target);
           const hasTargetStats = selectedTargets.some(target => target.targetStats &&
             target.targetStats.filter(targetStat => targetStat.optimizeForTarget).length)
@@ -935,6 +936,7 @@ const mapDispatchToProps = dispatch => ({
   toggleCharacterLock: (characterID) => dispatch(toggleCharacterLock(characterID)),
   updateLockUnselectedCharacters: (lock) => dispatch(updateLockUnselectedCharacters(lock)),
   resetAllCharacterTargets: () => dispatch(resetAllCharacterTargets()),
+  resetIncrementalIndex: () => dispatch(resetIncrementalIndex()),
   optimizeMods: () => dispatch(optimizeMods()),
   updateModChangeThreshold: (threshold) => dispatch(updateModChangeThreshold(threshold)),
   updateForceCompleteModSets: (forceCompleteModSets) => dispatch(updateForceCompleteModSets(forceCompleteModSets)),

--- a/src/containers/CharacterEditView/CharacterEditView.js
+++ b/src/containers/CharacterEditView/CharacterEditView.js
@@ -286,8 +286,6 @@ class CharacterEditView extends PureComponent {
       <button
         type={'button'}
         onClick={() => {
-          // TODO: Need to reset stopAt here, since by pressing this button we don't want incremental optimization
-          // this.props.profile.stopAt = "";
 
           const selectedTargets = this.props.selectedCharacters.map(({ target }) => target);
           const hasTargetStats = selectedTargets.some(target => target.targetStats &&

--- a/src/containers/CharacterEditView/CharacterEditView.js
+++ b/src/containers/CharacterEditView/CharacterEditView.js
@@ -907,7 +907,7 @@ const mapStateToProps = (state) => {
     lastSelectedCharacter: profile.selectedCharacters.length - 1,
     showReviewButton: profile.modAssignments && Object.keys(profile.modAssignments).length,
     characterTemplates: Object.keys(state.characterTemplates),
-    stopAt: profile.stopAt,
+    incrementalOptimizeIndex: profile.incrementalOptimizeIndex,
   };
 };
 

--- a/src/domain/OptimizerRun.js
+++ b/src/domain/OptimizerRun.js
@@ -7,6 +7,7 @@ export default class OptimizerRun {
   mods;
   selectedCharacters;
   globalSettings;
+  stopAt;
 
   /**
    * Note that all of the parameters for an OptimizerRun are pure Objects - no classes with extra methods built-in
@@ -18,8 +19,9 @@ export default class OptimizerRun {
    * @param globalSettings {Object} 
    * @param modChangeThreshold {number}
    * @param lockUnselectedCharacters {boolean}
+   * @param stopAt {string}
    */
-  constructor(allyCode, characters, mods, selectedCharacters, globalSettings) {
+  constructor(allyCode, characters, mods, selectedCharacters, globalSettings, stopAt) {
     this.allyCode = allyCode;
     // We care about everything stored for the character except the default settings
     mapObject(characters, character => {
@@ -30,6 +32,7 @@ export default class OptimizerRun {
     this.mods = mods;
     this.selectedCharacters = selectedCharacters;
     this.globalSettings = globalSettings;
+    this.stopAt = stopAt;
   }
 
   serialize() {
@@ -38,7 +41,8 @@ export default class OptimizerRun {
       characters: this.characters,
       mods: this.mods,
       selectedCharacters: this.selectedCharacters.map(({id, target}) => ({id: id, target: target.serialize()})),
-      globalSettings: this.globalSettings
+      globalSettings: this.globalSettings,
+      stopAt: this.stopAt
     };
   }
 
@@ -49,7 +53,8 @@ export default class OptimizerRun {
         runJson.characters,
         runJson.mods,
         runJson.selectedCharacters,
-        runJson.globalSettings
+        runJson.globalSettings,
+        runJson.stopAt
       );  
     } else {
       return this.deserializeVersionOneFive(runJson);
@@ -65,7 +70,8 @@ export default class OptimizerRun {
       Object.assign({}, PlayerProfile.defaultGlobalSettings, {
         modChangeThreshold: runJson.modChangeThreshold,
         lockUnselectedCharacters: runJson.lockUnselectedCharacters
-      })
+      }),
+      runJson.stopAt
     );
   }
 }

--- a/src/domain/OptimizerRun.js
+++ b/src/domain/OptimizerRun.js
@@ -7,7 +7,7 @@ export default class OptimizerRun {
   mods;
   selectedCharacters;
   globalSettings;
-  stopAt;
+  incrementalOptimizeIndex;
 
   /**
    * Note that all of the parameters for an OptimizerRun are pure Objects - no classes with extra methods built-in
@@ -19,9 +19,9 @@ export default class OptimizerRun {
    * @param globalSettings {Object} 
    * @param modChangeThreshold {number}
    * @param lockUnselectedCharacters {boolean}
-   * @param stopAt {string}
+   * @param incrementalOptimizeIndex {number}
    */
-  constructor(allyCode, characters, mods, selectedCharacters, globalSettings, stopAt) {
+  constructor(allyCode, characters, mods, selectedCharacters, globalSettings, incrementalOptimizeIndex) {
     this.allyCode = allyCode;
     // We care about everything stored for the character except the default settings
     mapObject(characters, character => {
@@ -32,7 +32,7 @@ export default class OptimizerRun {
     this.mods = mods;
     this.selectedCharacters = selectedCharacters;
     this.globalSettings = globalSettings;
-    this.stopAt = stopAt;
+    this.incrementalOptimizeIndex = incrementalOptimizeIndex;
   }
 
   serialize() {
@@ -42,7 +42,7 @@ export default class OptimizerRun {
       mods: this.mods,
       selectedCharacters: this.selectedCharacters.map(({id, target}) => ({id: id, target: target.serialize()})),
       globalSettings: this.globalSettings,
-      stopAt: this.stopAt
+      incrementalOptimizeIndex: this.incrementalOptimizeIndex
     };
   }
 
@@ -54,7 +54,7 @@ export default class OptimizerRun {
         runJson.mods,
         runJson.selectedCharacters,
         runJson.globalSettings,
-        runJson.stopAt
+        runJson.incrementalOptimizeIndex
       );  
     } else {
       return this.deserializeVersionOneFive(runJson);
@@ -71,7 +71,7 @@ export default class OptimizerRun {
         modChangeThreshold: runJson.modChangeThreshold,
         lockUnselectedCharacters: runJson.lockUnselectedCharacters
       }),
-      runJson.stopAt
+      runJson.incrementalOptimizeIndex
     );
   }
 }

--- a/src/domain/OptimizerRun.js
+++ b/src/domain/OptimizerRun.js
@@ -7,7 +7,6 @@ export default class OptimizerRun {
   mods;
   selectedCharacters;
   globalSettings;
-  incrementalOptimizeIndex;
 
   /**
    * Note that all of the parameters for an OptimizerRun are pure Objects - no classes with extra methods built-in
@@ -19,9 +18,8 @@ export default class OptimizerRun {
    * @param globalSettings {Object} 
    * @param modChangeThreshold {number}
    * @param lockUnselectedCharacters {boolean}
-   * @param incrementalOptimizeIndex {number}
    */
-  constructor(allyCode, characters, mods, selectedCharacters, globalSettings, incrementalOptimizeIndex) {
+  constructor(allyCode, characters, mods, selectedCharacters, globalSettings) {
     this.allyCode = allyCode;
     // We care about everything stored for the character except the default settings
     mapObject(characters, character => {
@@ -32,7 +30,6 @@ export default class OptimizerRun {
     this.mods = mods;
     this.selectedCharacters = selectedCharacters;
     this.globalSettings = globalSettings;
-    this.incrementalOptimizeIndex = incrementalOptimizeIndex;
   }
 
   serialize() {
@@ -42,7 +39,6 @@ export default class OptimizerRun {
       mods: this.mods,
       selectedCharacters: this.selectedCharacters.map(({id, target}) => ({id: id, target: target.serialize()})),
       globalSettings: this.globalSettings,
-      incrementalOptimizeIndex: this.incrementalOptimizeIndex
     };
   }
 
@@ -54,7 +50,6 @@ export default class OptimizerRun {
         runJson.mods,
         runJson.selectedCharacters,
         runJson.globalSettings,
-        runJson.incrementalOptimizeIndex
       );  
     } else {
       return this.deserializeVersionOneFive(runJson);
@@ -71,7 +66,6 @@ export default class OptimizerRun {
         modChangeThreshold: runJson.modChangeThreshold,
         lockUnselectedCharacters: runJson.lockUnselectedCharacters
       }),
-      runJson.incrementalOptimizeIndex
     );
   }
 }

--- a/src/domain/PlayerProfile.js
+++ b/src/domain/PlayerProfile.js
@@ -95,6 +95,21 @@ export default class PlayerProfile {
     }
   }
 
+  clearStopAt() {
+    return new PlayerProfile(
+      this.allyCode,
+      this.playerName,
+      this.characters,
+      this.mods,
+      this.selectedCharacters,
+      this.modAssignments,
+      this.globalSettings,
+      this.previousSettings,
+      this.hotUtilsSessionId,
+      ""
+    );
+}
+
   withMods(mods) {
     if (mods) {
       return new PlayerProfile(

--- a/src/domain/PlayerProfile.js
+++ b/src/domain/PlayerProfile.js
@@ -96,7 +96,7 @@ export default class PlayerProfile {
     }
   }
 
-  clearincrementalOptimizeIndex() {
+  resetIncrementalOptimizeIndex() {
     return new PlayerProfile(
       this.allyCode,
       this.playerName,

--- a/src/domain/PlayerProfile.js
+++ b/src/domain/PlayerProfile.js
@@ -16,7 +16,7 @@ export default class PlayerProfile {
   modAssignments;
   globalSettings;
   hotUtilsSessionId;
-  stopAt;
+  incrementalOptimizeIndex;
   // Deprecated
   previousSettings;
 
@@ -29,7 +29,8 @@ export default class PlayerProfile {
    * @param modAssignments {Array<Object>} An array of character definitions and assigned mods
    * @param globalSettings {Object} An object containing settings that apply in the context of a player, rather than a
    *                                character
-   * @param stopAt {string} Specify to terminate optimization at a specific character, for incremental optimization
+   * @param incrementalOptimizeIndex {number} Specify to terminate optimization at a specific character, for incremental optimization
+   * 
    * @param previousSettings {Object} Deprecated - An object that holds the previous values for characters, mods,
    *                                  selectedCharacters, and modChangeThreshold. If none of these have changed, then
    *                                  modAssignments shouldn't change on a reoptimization.
@@ -43,7 +44,7 @@ export default class PlayerProfile {
     globalSettings = PlayerProfile.defaultGlobalSettings,
     previousSettings = {},
     hotUtilsSessionId = null,
-    stopAt
+    incrementalOptimizeIndex = -1,
   ) {
     this.allyCode = allyCode;
     this.playerName = playerName;
@@ -54,7 +55,7 @@ export default class PlayerProfile {
     this.globalSettings = globalSettings;
     this.previousSettings = previousSettings;
     this.hotUtilsSessionId = hotUtilsSessionId;
-    this.stopAt = stopAt;
+    this.incrementalOptimizeIndex = incrementalOptimizeIndex;
   }
 
   withPlayerName(name) {
@@ -69,7 +70,7 @@ export default class PlayerProfile {
         this.globalSettings,
         this.previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       )
     } else {
       return this;
@@ -88,14 +89,14 @@ export default class PlayerProfile {
         this.globalSettings,
         this.previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       );
     } else {
       return this;
     }
   }
 
-  clearStopAt() {
+  clearincrementalOptimizeIndex() {
     return new PlayerProfile(
       this.allyCode,
       this.playerName,
@@ -106,7 +107,7 @@ export default class PlayerProfile {
       this.globalSettings,
       this.previousSettings,
       this.hotUtilsSessionId,
-      ""
+      -1,
     );
 }
 
@@ -122,7 +123,7 @@ export default class PlayerProfile {
         this.globalSettings,
         this.previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       );
     } else {
       return this;
@@ -141,7 +142,7 @@ export default class PlayerProfile {
         this.globalSettings,
         this.previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       );
     } else {
       return this;
@@ -160,7 +161,7 @@ export default class PlayerProfile {
         this.globalSettings,
         this.previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       );
     } else {
       return this;
@@ -178,7 +179,7 @@ export default class PlayerProfile {
       globalSettings,
       this.previousSettings,
       this.hotUtilsSessionId,
-      this.stopAt
+      this.incrementalOptimizeIndex,
     );
   }
 
@@ -194,7 +195,7 @@ export default class PlayerProfile {
         this.globalSettings,
         previousSettings,
         this.hotUtilsSessionId,
-        this.stopAt
+        this.incrementalOptimizeIndex,
       );
     } else {
       return this;
@@ -215,7 +216,7 @@ export default class PlayerProfile {
       this.globalSettings,
       {},
       this.hotUtilsSessionId,
-      this.stopAt
+      this.incrementalOptimizeIndex,
     );
   }
 
@@ -230,7 +231,7 @@ export default class PlayerProfile {
       this.globalSettings,
       this.previousSettings,
       id,
-      this.stopAt
+      this.incrementalOptimizeIndex,
     )
   }
 
@@ -245,7 +246,7 @@ export default class PlayerProfile {
       this.mods.map(mod => mod.serialize()),
       this.selectedCharacters,
       this.globalSettings,
-      this.stopAt
+      this.incrementalOptimizeIndex,
     );
   }
 
@@ -262,7 +263,7 @@ export default class PlayerProfile {
       globalSettings: this.globalSettings,
       previousSettings: this.previousSettings,
       hotUtilsSessionId: this.hotUtilsSessionId,
-      stopAt: this.stopAt
+      incrementalOptimizeIndex: this.incrementalOptimizeIndex,
     };
   }
 
@@ -283,7 +284,7 @@ export default class PlayerProfile {
         Object.assign({}, PlayerProfile.defaultGlobalSettings, profileJson.globalSettings),
         profileJson.previousSettings || {},
         profileJson.hotUtilsSessionId || null,
-        profileJson.stopAt || ""
+        profileJson.incrementalOptimizeIndex || -1,
       )
     } else {
       return null;
@@ -318,7 +319,7 @@ export default class PlayerProfile {
       globalSettings,
       profileJson.previousSettings || {},
       null,
-      profileJson.stopAt || ""
+      -1,
     );
   }
 }

--- a/src/domain/PlayerProfile.js
+++ b/src/domain/PlayerProfile.js
@@ -246,7 +246,6 @@ export default class PlayerProfile {
       this.mods.map(mod => mod.serialize()),
       this.selectedCharacters,
       this.globalSettings,
-      this.incrementalOptimizeIndex,
     );
   }
 

--- a/src/domain/PlayerProfile.js
+++ b/src/domain/PlayerProfile.js
@@ -16,6 +16,7 @@ export default class PlayerProfile {
   modAssignments;
   globalSettings;
   hotUtilsSessionId;
+  stopAt;
   // Deprecated
   previousSettings;
 
@@ -28,6 +29,7 @@ export default class PlayerProfile {
    * @param modAssignments {Array<Object>} An array of character definitions and assigned mods
    * @param globalSettings {Object} An object containing settings that apply in the context of a player, rather than a
    *                                character
+   * @param stopAt {string} Specify to terminate optimization at a specific character, for incremental optimization
    * @param previousSettings {Object} Deprecated - An object that holds the previous values for characters, mods,
    *                                  selectedCharacters, and modChangeThreshold. If none of these have changed, then
    *                                  modAssignments shouldn't change on a reoptimization.
@@ -40,7 +42,8 @@ export default class PlayerProfile {
     modAssignments = [],
     globalSettings = PlayerProfile.defaultGlobalSettings,
     previousSettings = {},
-    hotUtilsSessionId = null
+    hotUtilsSessionId = null,
+    stopAt
   ) {
     this.allyCode = allyCode;
     this.playerName = playerName;
@@ -51,6 +54,7 @@ export default class PlayerProfile {
     this.globalSettings = globalSettings;
     this.previousSettings = previousSettings;
     this.hotUtilsSessionId = hotUtilsSessionId;
+    this.stopAt = stopAt;
   }
 
   withPlayerName(name) {
@@ -64,7 +68,8 @@ export default class PlayerProfile {
         this.modAssignments,
         this.globalSettings,
         this.previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       )
     } else {
       return this;
@@ -82,7 +87,8 @@ export default class PlayerProfile {
         this.modAssignments,
         this.globalSettings,
         this.previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       );
     } else {
       return this;
@@ -100,7 +106,8 @@ export default class PlayerProfile {
         this.modAssignments,
         this.globalSettings,
         this.previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       );
     } else {
       return this;
@@ -118,7 +125,8 @@ export default class PlayerProfile {
         this.modAssignments,
         this.globalSettings,
         this.previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       );
     } else {
       return this;
@@ -136,7 +144,8 @@ export default class PlayerProfile {
         modAssignments,
         this.globalSettings,
         this.previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       );
     } else {
       return this;
@@ -153,7 +162,8 @@ export default class PlayerProfile {
       this.modAssignments,
       globalSettings,
       this.previousSettings,
-      this.hotUtilsSessionId
+      this.hotUtilsSessionId,
+      this.stopAt
     );
   }
 
@@ -168,7 +178,8 @@ export default class PlayerProfile {
         this.modAssignments,
         this.globalSettings,
         previousSettings,
-        this.hotUtilsSessionId
+        this.hotUtilsSessionId,
+        this.stopAt
       );
     } else {
       return this;
@@ -188,7 +199,8 @@ export default class PlayerProfile {
       this.modAssignments,
       this.globalSettings,
       {},
-      this.hotUtilsSessionId
+      this.hotUtilsSessionId,
+      this.stopAt
     );
   }
 
@@ -202,7 +214,8 @@ export default class PlayerProfile {
       this.modAssignments,
       this.globalSettings,
       this.previousSettings,
-      id
+      id,
+      this.stopAt
     )
   }
 
@@ -216,7 +229,8 @@ export default class PlayerProfile {
       mapObject(this.characters, character => character.serialize()),
       this.mods.map(mod => mod.serialize()),
       this.selectedCharacters,
-      this.globalSettings
+      this.globalSettings,
+      this.stopAt
     );
   }
 
@@ -232,7 +246,8 @@ export default class PlayerProfile {
       modAssignments: this.modAssignments,
       globalSettings: this.globalSettings,
       previousSettings: this.previousSettings,
-      hotUtilsSessionId: this.hotUtilsSessionId
+      hotUtilsSessionId: this.hotUtilsSessionId,
+      stopAt: this.stopAt
     };
   }
 
@@ -252,7 +267,8 @@ export default class PlayerProfile {
         profileJson.modAssignments,
         Object.assign({}, PlayerProfile.defaultGlobalSettings, profileJson.globalSettings),
         profileJson.previousSettings || {},
-        profileJson.hotUtilsSessionId || null
+        profileJson.hotUtilsSessionId || null,
+        profileJson.stopAt || ""
       )
     } else {
       return null;
@@ -286,7 +302,8 @@ export default class PlayerProfile {
       modAssignments,
       globalSettings,
       profileJson.previousSettings || {},
-      null
+      null,
+      profileJson.stopAt || ""
     );
   }
 }

--- a/src/state/actions/characterEdit.js
+++ b/src/state/actions/characterEdit.js
@@ -270,7 +270,7 @@ export function changeCharacterEditMode(mode) {
  * @param newTarget OptimizationPlan The new target to use for the character
  * @returns {Function}
  */
-export function finishEditCharacterTarget(characterIndex, newTarget) {
+export function finishEditCharacterTarget(characterIndex, newTarget, closeForm) {
   return updateProfile(
     profile => {
       if (characterIndex >= profile.selectedCharacters.length) {
@@ -283,14 +283,20 @@ export function finishEditCharacterTarget(characterIndex, newTarget) {
       const oldCharacter = profile.characters[characterID];
       const newCharacter = oldCharacter.withOptimizerSettings(oldCharacter.optimizerSettings.withTarget(newTarget));
 
+      // incremental optimization, set the stopAt
+      profile.stopAt = closeForm?"": newCharacter.baseID;
+
       return profile.withCharacters(Object.assign({}, profile.characters, {
         [newCharacter.baseID]: newCharacter
       })).withSelectedCharacters(newSelectedCharacters);
     },
     dispatch => {
-      dispatch(hideModal());
-      dispatch(changeSetRestrictions(null));
-      dispatch(changeTargetStats(null));
+      if(closeForm)
+      { 
+        dispatch(hideModal());
+        dispatch(changeSetRestrictions(null));
+        dispatch(changeTargetStats(null));
+      }
     }
   );
 }

--- a/src/state/actions/characterEdit.js
+++ b/src/state/actions/characterEdit.js
@@ -274,7 +274,7 @@ export function finishEditCharacterTarget(characterIndex, newTarget, closeForm) 
   return updateProfile(
     profile => {
       if (characterIndex >= profile.selectedCharacters.length) {
-        return profile.clearStopAt();
+        return profile.clearincrementalOptimizeIndex();
       }
       const newSelectedCharacters = profile.selectedCharacters.slice();
       const [{ id: characterID }] = newSelectedCharacters.splice(characterIndex, 1);
@@ -283,8 +283,8 @@ export function finishEditCharacterTarget(characterIndex, newTarget, closeForm) 
       const oldCharacter = profile.characters[characterID];
       const newCharacter = oldCharacter.withOptimizerSettings(oldCharacter.optimizerSettings.withTarget(newTarget));
 
-      // incremental optimization, set the stopAt
-      profile.stopAt = closeForm?"": newCharacter.baseID;
+      // incremental optimization, set the incrementalOptimizeIndex
+      profile.incrementalOptimizeIndex = closeForm?-1: characterIndex;
 
       return profile.withCharacters(Object.assign({}, profile.characters, {
         [newCharacter.baseID]: newCharacter

--- a/src/state/actions/characterEdit.js
+++ b/src/state/actions/characterEdit.js
@@ -274,7 +274,7 @@ export function finishEditCharacterTarget(characterIndex, newTarget, closeForm) 
   return updateProfile(
     profile => {
       if (characterIndex >= profile.selectedCharacters.length) {
-        return profile;
+        return profile.clearStopAt();
       }
       const newSelectedCharacters = profile.selectedCharacters.slice();
       const [{ id: characterID }] = newSelectedCharacters.splice(characterIndex, 1);

--- a/src/state/actions/characterEdit.js
+++ b/src/state/actions/characterEdit.js
@@ -274,7 +274,7 @@ export function finishEditCharacterTarget(characterIndex, newTarget, closeForm) 
   return updateProfile(
     profile => {
       if (characterIndex >= profile.selectedCharacters.length) {
-        return profile.clearincrementalOptimizeIndex();
+        return profile.resetIncrementalOptimizeIndex();
       }
       const newSelectedCharacters = profile.selectedCharacters.slice();
       const [{ id: characterID }] = newSelectedCharacters.splice(characterIndex, 1);
@@ -712,6 +712,15 @@ export function replaceTemplate(name) {
       );
     }
   }
+}
+
+export function resetIncrementalIndex() {
+  return updateProfile(
+    profile => {
+      const newProfile = profile.resetIncrementalOptimizeIndex();
+      return newProfile;
+    }
+  )
 }
 
 export function applyTemplateTargets(name) {

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -248,7 +248,7 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
           finalMods = Object.values(newMods);
         }
 
-        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods).clearincrementalOptimizeIndex();
+        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods).resetIncrementalOptimizeIndex();
         db.saveProfile(
           newProfile,
           nothing,

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -248,7 +248,7 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
           finalMods = Object.values(newMods);
         }
 
-        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods).clearStopAt();
+        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods).clearincrementalOptimizeIndex();
         db.saveProfile(
           newProfile,
           nothing,

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -248,7 +248,7 @@ function updatePlayerData(allyCode, fetchData, db, keepOldMods) {
           finalMods = Object.values(newMods);
         }
 
-        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods);
+        const newProfile = oldProfile.withCharacters(newCharacters).withMods(finalMods).clearStopAt();
         db.saveProfile(
           newProfile,
           nothing,

--- a/src/state/actions/optimize.js
+++ b/src/state/actions/optimize.js
@@ -140,13 +140,18 @@ export function optimizeMods() {
     optimizationWorker.onmessage = function (message) {
       if (incremental)
       {
-        if (message.data.type === 'OptimizationSuccess')
-        {
-          dispatch(setIsBusy(false));
-          dispatch(finishModOptimization(
-            message.data.result,
-            profile.toOptimizerRun()
-          ));
+        switch (message.data.type) {
+          case 'OptimizationSuccess':
+            dispatch(setIsBusy(false));
+            dispatch(finishModOptimization(
+              message.data.result,
+              profile.toOptimizerRun()
+            ));
+            break;
+          case 'Progress':
+            // TODO: Get some kind of visualization of progress for long running incremental optimizations here
+            break;
+          default: // do nothing
         }
         return;
         // don't show modals for incremental optimization.

--- a/src/state/actions/optimize.js
+++ b/src/state/actions/optimize.js
@@ -25,6 +25,7 @@ export function startModOptimization() {
  * @returns {*}
  */
 export function finishModOptimization(result, settings) {
+
   return updateProfile(
     profile => profile.withModAssignments(result),
     (dispatch, getState, newProfile) => {
@@ -39,8 +40,15 @@ export function finishModOptimization(result, settings) {
           ' The optimizer may not recalculate correctly on your next optimization'
         ))
       );
-
+      const stopAt = newProfile.stopAt;
+      const incremental = stopAt && stopAt !== "";
       dispatch(setIsBusy(false));
+      if (incremental)
+      {
+        return;
+      }
+      else
+      {
       dispatch(updateModListFilter({
         view: 'sets',
         sort: 'assignedCharacter'
@@ -96,6 +104,7 @@ export function finishModOptimization(result, settings) {
         ));
       }
     }
+  }
   );
 }
 
@@ -114,6 +123,7 @@ let optimizationWorker = null;
 export function optimizeMods() {
   return function (dispatch, getState) {
     const profile = getState().profile;
+    const incremental = profile.stopAt && profile.stopAt !== "";
     // If any of the characters being optimized don't have stats, then show an error message
     if (Object.values(profile.characters)
       .filter(char => null === char.playerValues.baseStats || null === char.playerValues.equippedStats)
@@ -128,6 +138,19 @@ export function optimizeMods() {
       new Worker(`/workers/optimizer.js?version=${process.env.REACT_APP_VERSION || 'local'}`);
 
     optimizationWorker.onmessage = function (message) {
+      if (incremental)
+      {
+        if (message.data.type === 'OptimizationSuccess')
+        {
+          dispatch(setIsBusy(false));
+          dispatch(finishModOptimization(
+            message.data.result,
+            profile.toOptimizerRun()
+          ));
+        }
+        return;
+        // don't show modals for incremental optimization.
+      } 
       switch (message.data.type) {
         case 'OptimizationSuccess':
           dispatch(setIsBusy(false));

--- a/src/state/actions/optimize.js
+++ b/src/state/actions/optimize.js
@@ -40,8 +40,8 @@ export function finishModOptimization(result, settings) {
           ' The optimizer may not recalculate correctly on your next optimization'
         ))
       );
-      const stopAt = newProfile.stopAt;
-      const incremental = stopAt && stopAt !== "";
+      const incrementalOptimizeIndex = newProfile.incrementalOptimizeIndex;
+      const incremental = incrementalOptimizeIndex >= 0;
       dispatch(setIsBusy(false));
       if (incremental)
       {
@@ -123,7 +123,7 @@ let optimizationWorker = null;
 export function optimizeMods() {
   return function (dispatch, getState) {
     const profile = getState().profile;
-    const incremental = profile.stopAt && profile.stopAt !== "";
+    const incremental = profile.incrementalOptimizeIndex >= 0;
     // If any of the characters being optimized don't have stats, then show an error message
     if (Object.values(profile.characters)
       .filter(char => null === char.playerValues.baseStats || null === char.playerValues.equippedStats)

--- a/src/state/actions/storage.js
+++ b/src/state/actions/storage.js
@@ -264,7 +264,7 @@ export function loadProfile(allyCode) {
       allyCode,
       profile => {
         const cleanedSelectedCharacters =
-          profile.selectedCharacters.filter(({ id }) => Object.keys(profile.characters).includes(id));
+          profile.selectedCharacters?.filter(({ id }) => Object.keys(profile.characters).includes(id));
         const cleanedProfile = profile.withSelectedCharacters(cleanedSelectedCharacters);
 
         dispatch(setProfile(cleanedProfile));


### PR DESCRIPTION
This is provided as a working POC for the change to improve remodding workflow by allowing users to work down their priority list toon by toon and trigger optimizations from within the character edit form directly.

Very much a first draft, more arse than class.

This PR does the following things:
1. Expose missed targets on the CharacterEditForm for quick reference.
2. Add a "Save and Run" button to the character edit form that saves the current targets and runs an "incremental" optimization (i.e. only up to the currently viewed character.)

I would like for the CharacterEditForm to remain open and updated missed targets info to be displayed, but haven't managed to work that out. For now you can see what the intention is. 