### PR TITLE
Add secondary stat rating

### DIFF
--- a/src/components/ModDetail/ModDetail.css
+++ b/src/components/ModDetail/ModDetail.css
@@ -13,7 +13,7 @@
   text-shadow: 2px 2px 1px black;
   margin: 1em;
   padding: 1em;
-  width: 18em;
+  width: 22em;
 }
 
 .mod-detail .mod-image,

--- a/src/components/ModFilter/ModFilter.js
+++ b/src/components/ModFilter/ModFilter.js
@@ -10,7 +10,7 @@ import { changeModsFilter } from "../../state/actions/explore";
 import Pips from "../Pips/Pips";
 import { Dropdown } from '../Dropdown/Dropdown';
 
-function cycleState(e) {
+function cycleState (e) {
   e.target.value = e.target.valueAsNumber + 1;
   if (e.target.value > 1) {
     e.target.value = -1;
@@ -24,18 +24,18 @@ function cycleState(e) {
   }
 }
 
-function selectElement(element) {
+function selectElement (element) {
   element.value = 1;
   element.classList.remove('unselect');
   element.classList.add('select');
 }
 
-function unselectElement(element) {
+function unselectElement (element) {
   element.value = 0;
   element.classList.remove('select', 'unselect');
 }
 
-function classForValue(value) {
+function classForValue (value) {
   switch (value) {
     case 1: return 'select';
     case -1: return 'unselect';
@@ -64,7 +64,7 @@ class ModFilter extends React.PureComponent {
    * Render the slot filter inputs
    * @returns {JSX Element}
    */
-  slotFilter() {
+  slotFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       ModSet.slots.forEach(slot => selectElement(document.getElementById(`slot-filter-${slot}`)));
@@ -106,7 +106,7 @@ class ModFilter extends React.PureComponent {
    * Render the set filter inputs
    * @returns {JSX Element}
    */
-  setFilter() {
+  setFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       Object.keys(setBonuses)
@@ -150,7 +150,7 @@ class ModFilter extends React.PureComponent {
    * Render the pips filter inputs
    * @returns {*}
    */
-  rarityFilter() {
+  rarityFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       [1, 2, 3, 4, 5, 6]
@@ -196,7 +196,7 @@ class ModFilter extends React.PureComponent {
    * Render the mod tier filter inputs
    * @returns {*}
    */
-  tierFilter() {
+  tierFilter () {
     const tiers = {
       5: 'gold',
       4: 'purple',
@@ -249,7 +249,7 @@ class ModFilter extends React.PureComponent {
    * Render the level filter inputs
    * @returns {*}
    */
-  levelFilter() {
+  levelFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
@@ -290,7 +290,7 @@ class ModFilter extends React.PureComponent {
     </div>;
   }
 
-  equippedFilter() {
+  equippedFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       ['equipped', 'unequipped'].forEach(equipState =>
@@ -339,7 +339,7 @@ class ModFilter extends React.PureComponent {
    * @param mods [Mod] the list of mods being filtered
    * @returns {JSX Element}
    */
-  primaryStatFilter(mods) {
+  primaryStatFilter (mods) {
     const primaryStats = mods.map(mod => mod.primaryStat.type)
       .reduce((acc, stat) => acc.includes(stat) ? acc : acc.concat([stat]), [])
       .sort();
@@ -385,7 +385,7 @@ class ModFilter extends React.PureComponent {
    * @param mods [Mod] the list of mods being filtered
    * @returns {JSX Element}
    */
-  secondaryStatFilter(mods) {
+  secondaryStatFilter (mods) {
     const secondaryStats = mods.map(mod => mod.secondaryStats)
       .reduce((acc, stats) => acc.concat(stats), [])
       .map(stat => stat.type)
@@ -432,7 +432,7 @@ class ModFilter extends React.PureComponent {
    * Render filters that will show or hide mods based on whether the optimizer
    * has assigned them to any characters
    */
-  optimizerFilter() {
+  optimizerFilter () {
     const selectAll = (e) => {
       e.preventDefault();
       ['assigned', 'unassigned'].forEach(assignedState =>
@@ -481,7 +481,7 @@ class ModFilter extends React.PureComponent {
    * @param mods [Mod] the list of mods being sorted
    * @returns {JSX Element}
    */
-  sortOption(mods) {
+  sortOption (mods) {
     const secondaryStats = mods.map(mod => mod.secondaryStats)
       .reduce((acc, stats) => acc.concat(stats), [])
       .map(stat => stat.type)
@@ -498,6 +498,7 @@ class ModFilter extends React.PureComponent {
         <option value={''}>default</option>
         <option value={'rolls'}># of Stat Upgrades</option>
         <option value={'offenseScore'}>Offense Score</option>
+        <option value={'secondaryStatScore'}>Secondary Stat Score</option>
         <option value={'character'}>Character</option>
         {sortOptions}
       </Dropdown>
@@ -507,7 +508,7 @@ class ModFilter extends React.PureComponent {
   /**
    * Reset all filters so that all values are selected
    */
-  resetFilters() {
+  resetFilters () {
     [...document.getElementById('mod-filters').getElementsByTagName('input')]
       .forEach(element => unselectElement(element));
     [...document.getElementById('mod-filters').getElementsByTagName('select')].forEach(element => {
@@ -519,7 +520,7 @@ class ModFilter extends React.PureComponent {
    * @returns Object an object with keys for 'slot', 'set', 'primary', 'secondary', each containing an
    *                 array of selected values, plus 'sort', containing the value to sort by
    */
-  collectFilters(form) {
+  collectFilters (form) {
     const filters = {};
 
     [...form.elements].filter(element => element.name.includes('-filter-')).forEach(element => {
@@ -535,7 +536,7 @@ class ModFilter extends React.PureComponent {
     return filters;
   }
 
-  render() {
+  render () {
     const mods = this.props.mods;
     const onSubmit = (e) => {
       e.preventDefault();

--- a/src/components/ModStats/ModStats.css
+++ b/src/components/ModStats/ModStats.css
@@ -1,6 +1,6 @@
 .mod-stats {
   text-align: left;
-  width: 13em;
+  width: 17em;
   position: relative;
 }
 
@@ -49,6 +49,18 @@
 
 .mod-stats .class-D {
   color: #ccfffe;
+}
+
+.stat-rating {
+  float: right;
+  cursor: zoom-in;
+  font-size: 0.5em;
+}
+
+.mod-rating {
+  cursor: zoom-in;
+  font-size: 1em;
+  padding-bottom: 1em;
 }
 
 .mod-stats .avatar {

--- a/src/components/ModStats/ModStats.js
+++ b/src/components/ModStats/ModStats.js
@@ -1,19 +1,50 @@
 // @flow
-
 import React from 'react';
 import './ModStats.css';
 import CharacterAvatar from "../CharacterAvatar/CharacterAvatar";
-import {connect} from "react-redux";
+import { connect } from "react-redux";
 import SellModButton from "../SellModButton/SellModButton";
+import { modSecondaryStatScore } from '../../utils/subjectiveScoring'
+
+function printStatRating (score, bonus = 0, forceBlack = false) {
+  const total = score + bonus;
+  const symbol = (bonus > 0 || forceBlack) ? '★' : '☆';
+
+  switch (true) {
+    case total >= 90:
+      return symbol.repeat(5);
+    case total >= 80:
+      return '½' + symbol.repeat(4);
+    case total >= 70:
+      return symbol.repeat(4);
+    case total >= 60:
+      return '½' + symbol.repeat(3);
+    case total >= 50:
+      return symbol.repeat(3);
+    case total >= 40:
+      return '½' + symbol.repeat(2);
+    case total >= 30:
+      return symbol.repeat(2);
+    case total >= 20:
+      return '½' + symbol.repeat(1);
+    case total >= 10:
+      return symbol.repeat(1);
+    case total >= 1:
+      return '½';
+    default:
+      return '⚐';
+  }
+}
 
 class ModStats extends React.PureComponent {
-  render() {
+  render () {
     const mod = this.props.mod;
     const character = mod.characterID ? this.props.characters[mod.characterID] : null;
     const showAvatar = 'showAvatar' in this.props;
+    const modStatScore = modSecondaryStatScore(mod);
     const statsDisplay = mod.secondaryStats.length > 0 ?
       mod.secondaryStats.map(
-        (stat, index) => ModStats.showStatElement(stat, index)
+        (stat, index) => ModStats.showStatElement(stat, modStatScore.statScores[index], index)
       ) : [<li key={0}>None</li>];
 
     const assignedCharacter = this.props.assignedCharacter;
@@ -25,25 +56,26 @@ class ModStats extends React.PureComponent {
         <ul>
           <li>{mod.primaryStat.show()}</li>
         </ul>
-        <h4>Secondary Stats</h4>
+        <h4>Secondary Stats<br /></h4>
         <ul className='secondary'>
           {statsDisplay}
         </ul>
+        <h4 className="mod-rating" title={'Overall Score: ' + modStatScore.overall}>{printStatRating(modStatScore.overall, undefined, true)}</h4>
         {showAvatar && character &&
-        <div className={'assigned-character'}>
-          <h4>Assigned To</h4>
-          <CharacterAvatar character={character}/>
-          <span className="avatar-name">
-            {this.props.gameSettings[character.baseID] ? this.props.gameSettings[character.baseID].name : character.baseID}
-          </span>
-        </div>
+          <div className={'assigned-character'}>
+            <h4>Assigned To</h4>
+            <CharacterAvatar character={character} />
+            <span className="avatar-name">
+              {this.props.gameSettings[character.baseID] ? this.props.gameSettings[character.baseID].name : character.baseID}
+            </span>
+          </div>
         }
         {showAvatar && <SellModButton mod={mod} />}
         {assignedCharacter && assignedTarget && mod.shouldLevel(assignedTarget) &&
-        <h4 className={'gold'}>Level mod to 15!</h4>
+          <h4 className={'gold'}>Level mod to 15!</h4>
         }
         {assignedCharacter && assignedTarget && mod.shouldSlice(assignedCharacter, assignedTarget) &&
-        <h4 className={'gold'}>Slice mod to 6E!</h4>
+          <h4 className={'gold'}>Slice mod to 6E!</h4>
         }
       </div>
     );
@@ -55,11 +87,13 @@ class ModStats extends React.PureComponent {
    * @param stat object The stat to display, with 'value' and 'type' fields
    * @param index integer The array index of this stat for this mod
    */
-  static showStatElement(stat, index) {
+  static showStatElement (stat, score, index) {
     return <li key={index} className={'class-' + stat.getClass()}>
       <span className={'rolls'}>({stat.rolls})</span> {stat.show()}
+      <span title={'Score: ' + score.score + (score.bonus ? ' + ' + score.bonus : '')} className="stat-rating">{printStatRating(score.score, score.bonus)}</span>
     </li>;
   }
+
 }
 
 const mapStateToProps = (state) => ({

--- a/src/constants/statRoll.js
+++ b/src/constants/statRoll.js
@@ -1,0 +1,113 @@
+// @flow
+
+// A map of min and max value per roll for each type of secondary stats,
+// numbered by mod rarity
+//
+// Ref:
+//  https://wiki.swgoh.help/wiki/Mods
+//  https://forums.galaxy-of-heroes.starwars.ea.com/discussion/178037/a-very-brief-overview-of-upcoming-mod-changes
+
+const statRoll = {
+  'MIN_ROLLS': 1,
+  'MAX_ROLLS': 5,
+  'Critical Chance %': {
+    1: { min: 0.5, max: 1 },
+    2: { min: 0.625, max: 1.25 },
+    3: { min: 0.75, max: 1.5 },
+    4: { min: 1, max: 2 },
+    5: { min: 1.125, max: 2.25 },
+    6: { min: 1.175, max: 2.35 }
+  },
+  'Defense': {
+    1: { min: 2, max: 4 },
+    2: { min: 2, max: 5 },
+    3: { min: 3, max: 6 },
+    4: { min: 4, max: 8 },
+    5: { min: 4, max: 10 },
+    6: { min: 8, max: 16 }
+  },
+  'Defense %': {
+    1: { min: 0.5, max: 1 },
+    2: { min: 0.55, max: 1.1 },
+    3: { min: 0.65, max: 1.3 },
+    4: { min: 0.75, max: 1.5 },
+    5: { min: 0.85, max: 1.7 },
+    6: { min: 1.989, max: 3.978 }
+  },
+  'Health': {
+    1: { min: 99, max: 199 },
+    2: { min: 118, max: 236 },
+    3: { min: 150, max: 300 },
+    4: { min: 173, max: 347 },
+    5: { min: 214, max: 428 },
+    6: { min: 270, max: 540 }
+  },
+  'Health %': {
+    1: { min: 0.25, max: 0.5 },
+    2: { min: 0.313, max: 0.626 },
+    3: { min: 0.375, max: 0.75 },
+    4: { min: 0.5, max: 1 },
+    5: { min: 0.563, max: 1.125 },
+    6: { min: 1, max: 2 }
+  },
+  'Offense': {
+    1: { min: 8, max: 16 },
+    2: { min: 10, max: 20 },
+    3: { min: 14, max: 28 },
+    4: { min: 18, max: 36 },
+    5: { min: 23, max: 46 },
+    6: { min: 26, max: 51 }
+  },
+  'Offense %': {
+    1: { min: 0.125, max: 0.25 },
+    2: { min: 0.156, max: 0.313 },
+    3: { min: 0.188, max: 0.375 },
+    4: { min: 0.25, max: 0.5 },
+    5: { min: 0.281, max: 0.563 },
+    6: { min: 0.85, max: 1.7 }
+  },
+  'Potency %': {
+    1: { min: 0.5, max: 1 },
+    2: { min: 0.625, max: 1.25 },
+    3: { min: 0.75, max: 1.5 },
+    4: { min: 1, max: 2 },
+    5: { min: 1.125, max: 2.25 },
+    6: { min: 1.5, max: 3 }
+  },
+  'Protection': {
+    1: { min: 99, max: 199 },
+    2: { min: 154, max: 309 },
+    3: { min: 240, max: 483 },
+    4: { min: 319, max: 639 },
+    5: { min: 415, max: 830 },
+    6: { min: 460, max: 921 }
+  },
+  'Protection %': {
+    1: { min: 0.5, max: 1 },
+    2: { min: 0.63, max: 1.25 },
+    3: { min: 0.75, max: 1.5 },
+    4: { min: 1, max: 2 },
+    5: { min: 1.125, max: 2.25 },
+    6: { min: 1.5, max: 3 }
+  },
+  'Speed': {
+    1: { min: 1, max: 2 },
+    2: { min: 1, max: 3 },
+    3: { min: 2, max: 4 },
+    4: { min: 2, max: 5 },
+    5: { min: 3, max: 6 },
+    6: { min: 3, max: 6 }
+  },
+  'Tenacity %': {
+    1: { min: 0.5, max: 1 },
+    2: { min: 0.625, max: 1.25 },
+    3: { min: 0.75, max: 1.5 },
+    4: { min: 1, max: 2 },
+    5: { min: 1.125, max: 2.25 },
+    6: { min: 1.5, max: 3 }
+  }
+}
+
+Object.freeze(statRoll);
+
+export default statRoll;

--- a/src/containers/ExploreView/ExploreView.js
+++ b/src/containers/ExploreView/ExploreView.js
@@ -11,10 +11,10 @@ import './ExploreView.css';
 import { connect } from "react-redux";
 import Sidebar from "../../components/Sidebar/Sidebar";
 
-import offenseScore from "../../utils/subjectiveScoring";
+import { offenseScore, modSecondaryStatScore } from "../../utils/subjectiveScoring";
 
 class ExploreView extends React.PureComponent {
-  render() {
+  render () {
     const modElements = this.props.displayedMods.map(mod => {
       const assignedCharacter = this.props.modAssignments[mod.id] ?
         this.props.characters[this.props.modAssignments[mod.id]] :
@@ -42,7 +42,7 @@ class ExploreView extends React.PureComponent {
    * Render the "Are you sure?" modal for deleting all displayed mods
    * @returns {*}
    */
-  deleteModsModal() {
+  deleteModsModal () {
     return <div>
       <h2>Delete All Displayed Mods</h2>
       <p>
@@ -63,7 +63,7 @@ class ExploreView extends React.PureComponent {
    * Render the sidebar content
    * @returns {*}
    */
-  static sidebar() {
+  static sidebar () {
     return <div className={'filters'} key={'filters'}>
       <ModFilter />
     </div>;
@@ -192,6 +192,14 @@ const getFilteredMods = memoize(
         filteredMods = filteredMods.sort((left, right) => {
           const leftValue = offenseScore(left);
           const rightValue = offenseScore(right);
+
+          return rightValue - leftValue;
+        });
+        break;
+      case 'secondaryStatScore':
+        filteredMods = filteredMods.sort((left, right) => {
+          const leftValue = modSecondaryStatScore(left).overall;
+          const rightValue = modSecondaryStatScore(right).overall;
 
           return rightValue - leftValue;
         });

--- a/src/utils/subjectiveScoring.js
+++ b/src/utils/subjectiveScoring.js
@@ -1,3 +1,5 @@
+import statRoll from '../constants/statRoll'
+
 /**
  * Return a score (suitable for sorting) of the offensive power of a mod.  This is a subjective score
  * based on the relative value of different types of sets and stats.  It is along the lines of the
@@ -7,7 +9,7 @@
  *
  * @param mod Mod
  */
-export default function offenseScore(mod) {
+export function offenseScore (mod) {
   // weights for the set (mod type), primary attribute and secondary attributes
   const setScore = {
     'offense': 50,
@@ -42,3 +44,123 @@ export default function offenseScore(mod) {
   return mod.secondaryStats.concat([mod.primaryStat])
     .reduce((acc, stat) => acc + statScore[stat.type] * stat.value, setScore[mod.set.name]);
 };
+
+/**
+ * Return a score of a single secondary stat based on its degree of value, rolls, and matching set.
+ * 
+ * First, determine a base score (0-100) (s) representing magnitude of the value yielded from stat rolls.
+ * Second, scale the base score up/down adhering to number of rolls (S).
+ * Last, if stat type matches mod type and the score is considerably good, give additional bonus (B).
+ * 
+ * Max score is 20 / roll excluding bonus
+ * 
+ * @param {stat} Stat 
+ * @param {mod} Mod
+ *  
+ * @returns {{score: number, bonus: number }} Score and bonus of a single stat
+ */
+export function singleSecondaryStatScore (stat, mod) {
+
+  // Bonus for matching set
+  const bonusMultiplier = {
+    'offense': {
+      'Speed': 0.5,
+      'Offense': 0.3,
+      'Offense %': 0.3,
+      'Critical Chance %': 0.2
+    },
+    'critdamage': {
+      'Speed': 0.5,
+      'Offense': 0.2,
+      'Offense %': 0.2,
+      'Critical Chance %': 0.2
+    },
+    'speed': {
+      'Speed': 0.5
+    },
+    'critchance': {
+      'Speed': 0.5,
+      'Offense': 0.2,
+      'Offense %': 0.2,
+      'Critical Chance %': 0.3,
+    },
+    'potency': {
+      'Speed': 0.5,
+      'Potency %': 0.5
+    },
+    'defense': {
+      'Speed': 0.5,
+      'Defense': 0.3,
+      'Defense %': 0.3,
+      'Health': 0.2,
+      'Health %': 0.2,
+      'Protection': 0.2,
+      'Protection %': 0.2
+    },
+    'health': {
+      'Speed': 0.5,
+      'Health': 0.2,
+      'Health %': 0.2,
+      'Protection': 0.2,
+      'Protection %': 0.2
+    },
+    'tenacity': {
+      'Speed': 0.5,
+      'Tenacity %': 0.5
+    }
+  }
+
+  const min = statRoll[stat.type][mod.pips].min;
+  const max = statRoll[stat.type][mod.pips].max;
+  const range = max - min;
+  const avg = stat.value / stat.rolls;
+  let baseScore = (avg - min) / range * 100; // (s)
+  // SIMULATE 6E if the mod is 5A (15)
+  // if (mod.pips === 5 && mod.level === 15) {
+  //   const newStat = stat.upgradeSecondary();
+  //   const min = statRoll[stat.type][mod.pips + 1].min;
+  //   const max = statRoll[stat.type][mod.pips + 1].max;
+  //   const range = max - min;
+  //   const avg = newStat.value / stat.rolls;
+  //   baseScore = (avg - min) / range * 100; // (s)
+  // }
+  const score = baseScore * stat.rolls / statRoll['MAX_ROLLS']; // (S)
+
+  let bonus;
+  if (bonusMultiplier[mod.set.name].hasOwnProperty(stat.type)) {
+    if (baseScore >= 60 && stat.rolls >= 3)
+      bonus = score * bonusMultiplier[mod.set.name][stat.type]; // (B)
+  }
+
+  return {
+    score: Math.round(score * 100) / 100 || 0,
+    bonus: Math.round(bonus * 100) / 100 || 0
+  }
+
+}
+
+/**
+ * Return a score of a mod based on all of its secondary stats. 
+ * 
+ * Base score is 20 * max rolls of the mod.
+ * Final score is then scaled to 0-100.
+ * 
+ * @param {mod} Mod 
+ * @returns {{ overall: number, statScores: array of { score: number, bonus: number}}} Overall score of a mod and each of its individual stats
+ */
+
+export function modSecondaryStatScore (mod) {
+
+  const maxRolls = mod.pips === 6 ? mod.pips + mod.tier + 1 : mod.pips === 5 ? mod.pips + mod.tier - 2 : 4;
+  const maxScore = maxRolls * 20;
+  const statScores = mod.secondaryStats.length > 0 ?
+    mod.secondaryStats.map(
+      (stat, index) => singleSecondaryStatScore(stat, mod)
+    ) : [];
+
+  return {
+    overall: (statScores.reduce((acc, cur) => acc + cur.score + cur.bonus, 0) / maxScore * 100).toFixed(2),
+    statScores: statScores
+  }
+
+}


### PR DESCRIPTION
This should make reviewing mods and deciding which one to upgrade more easier and enjoyable.
The calculation is based on the magnitude of the value yielded from stat roll, number of rolls and matching set.

For individual stat rating:
- (1) Stat with 1 star-rating is considerably good tho would not benefit the character much.
- (2) Stat with 2 star-rating is better.
- (3) Stat with 2 star-rating means the value yielded from each roll is below the 'good' range.
- (4) Stat with 2 star-rating is worse.
- (5) Stat with 5 star-rating is GOLD.

Stat with ★ instead of ☆ means both its value and roll are above the spectrum and the type matches with the mod. It also  gains bonus score.

For overall mod rating:
It takes mod tier/rarity into consideration and scale the accumulated score accordingly.
