### PR TITLE
Update secondary stat rating with the new *badge* display

### DIFF
--- a/src/components/ModStats/ModStats.css
+++ b/src/components/ModStats/ModStats.css
@@ -64,6 +64,18 @@
   padding-bottom: 1em;
 }
 
+.mod-rating .badge-0 {
+  text-shadow: none;
+}
+
+.mod-rating .badge-1 {
+  text-shadow: 0 2px 2px white, 1px 1px 3px white;
+}
+
+.mod-rating .badge-2 {
+  text-shadow: 0 2px 2px gold, 1px 1px 3px gold;
+}
+
 .mod-stats .avatar {
   display: inline-block;
   vertical-align: middle;

--- a/src/components/ModStats/ModStats.css
+++ b/src/components/ModStats/ModStats.css
@@ -58,7 +58,7 @@
 }
 
 .mod-rating {
-  float: left;
+  text-align: left;
   cursor: default;
   font-size: 1em;
   padding-bottom: 1em;

--- a/src/components/ModStats/ModStats.js
+++ b/src/components/ModStats/ModStats.js
@@ -6,13 +6,6 @@ import { connect } from "react-redux";
 import SellModButton from "../SellModButton/SellModButton";
 import { modSecondaryStatScore } from '../../utils/subjectiveScoring'
 
-function printStarRating(score, forceBlack = false) {
-  const symbol = forceBlack ? '★' : '☆';
-  const stars = Math.floor(score / 20);
-  const modulus = score % 20;
-  return `${modulus >= 15 ? '¾' : modulus >= 10 ? '½' : modulus >= 5 ? '¼' : stars >= 1 ? '' : '∅'}${symbol.repeat(stars)}`;
-}
-
 class ModStats extends React.PureComponent {
   render() {
     const mod = this.props.mod;
@@ -21,7 +14,7 @@ class ModStats extends React.PureComponent {
     const modStatScore = modSecondaryStatScore(mod);
     const statsDisplay = mod.secondaryStats.length > 0 ?
       mod.secondaryStats.map(
-        (stat, index) => ModStats.showStatElement(stat, modStatScore.statScores[index], modStatScore.bonusIndex, index)
+        (stat, index) => ModStats.showStatElement(stat, modStatScore.statScores[index], modStatScore.bonusIndex.includes(index), index)
       ) : [<li key={0}>None</li>];
 
     const assignedCharacter = this.props.assignedCharacter;
@@ -37,7 +30,7 @@ class ModStats extends React.PureComponent {
         <ul className='secondary'>
           {statsDisplay}
         </ul>
-        <h4 className="mod-rating" title={`Mod Score: ${modStatScore.modScore} ${(modStatScore.bonusScore > 0 ? ` + ${modStatScore.bonusScore}` : '')} (${modStatScore.totalScore})`}>{printStarRating(modStatScore.modScore, true)}{(modStatScore.badges.length > 0 ? ' + ' + modStatScore.badges.join() : '')}</h4>
+        <h4 className="mod-rating" title={`Mod Score: ${modStatScore.modScore} ${(modStatScore.bonusScore > 0 ? ` + ${modStatScore.bonusScore}` : '')} (${modStatScore.totalScore})`}>{ModStats.printStarRating(modStatScore.modScore, true)}{(modStatScore.badges.length > 0 ? ' + ' : '')}{ModStats.printBadges(modStatScore.badges)}</h4>
         {showAvatar && character &&
           <div className={'assigned-character'}>
             <h4>Assigned To</h4>
@@ -62,13 +55,37 @@ class ModStats extends React.PureComponent {
    * Write out the string to display a stat's value, category, and class
    *
    * @param stat object The stat to display, with 'value' and 'type' fields
+   * @param score object The score of the stat, with 'value' and 'percentage' fields
+   * @param bonus bool True if a stat is met with the bonus requirements
    * @param index integer The array index of this stat for this mod
    */
-  static showStatElement(stat, score, bonusIndex, index) {
+  static showStatElement(stat, score, bonus, index) {
     return <li key={index} className={'class-' + stat.getClass()}>
       <span className={'rolls'}>({stat.rolls})</span> {stat.show()}
-      <span title={'Score: ' + score.score + ' (' + score.percentage + '%)'} className="stat-rating">{printStarRating(score.score, bonusIndex.includes(index))}</span>
+      <span title={'Score: ' + score.score + ' (' + score.percentage + '%)'} className="stat-rating">{ModStats.printStarRating(score.score, bonus)}</span>
     </li>;
+  }
+
+  /**
+   * Write out bonus badges
+   *
+   * @param {badges} object The badges to display, with 'badge' and 'flag' fields
+   */
+  static printBadges(badges) {
+    return badges.map((badge, index) => <span key={index} className={'badge-' + badge.flag}> {badge.badge} </span>);
+  }
+
+  /**
+   * Write out star rating
+   *
+   * @param {score} number The score to be displayed as stars 
+   * @param {black} bool Whether to display black or hollow stars
+   */
+  static printStarRating(score, black = false) {
+    const symbol = black ? '★' : '☆';
+    const stars = Math.floor(score / 20);
+    const modulus = score % 20;
+    return `${modulus >= 15 ? '¾' : modulus >= 10 ? '½' : modulus >= 5 ? '¼' : stars >= 1 ? '' : '∅'}${symbol.repeat(stars)}`;
   }
 }
 

--- a/src/containers/ExploreView/ExploreView.js
+++ b/src/containers/ExploreView/ExploreView.js
@@ -198,8 +198,8 @@ const getFilteredMods = memoize(
         break;
       case 'secondaryStatScore':
         filteredMods = filteredMods.sort((left, right) => {
-          const leftValue = modSecondaryStatScore(left).overall;
-          const rightValue = modSecondaryStatScore(right).overall;
+          const leftValue = modSecondaryStatScore(left).totalScore;
+          const rightValue = modSecondaryStatScore(right).totalScore;
 
           return rightValue - leftValue;
         });


### PR DESCRIPTION
The star rating will be displaying only the score of the secondaries without bonus added.
Bonus will be displayed separately as badges instead, for example:

Old rating:
SECONDARY STATS
(5) 25 Speed ★★★★★
(3) 6.52% Critical Chance ☆☆☆
(3) 3.48% Offense ½ ☆
(1) 1.7% Protection ½
★★★★

New rating:
SECONDARY STATS
(5) 25 Speed ¼★★★
(3) 6.52% Critical Chance ½★★
(3) 3.48% Offense ★
(1) 1.7% Protection ∅
¾★★ + ⚡️,⚔️

So the users should have a clearer view of the mod's intrinsic value of the secondaries.

The bonus calculation is now done by averaging the percentages from all secondaries with the same type:
⚡️ minimum 3 rolls and at least 60%/roll of speed secondary.
⚔️ minimum 4 rolls and at least 60%/roll of flat/percent offense or critical chance secondaries altogether.
🛡️ minimum 4 rolls and at least 60%/roll of flat/percent health, protection or defense secondaries altogether.
☠️ minimum 3 rolls and at least 60%/roll of potency secondary.
✊ minimum 3 rolls and at least 60%/roll of tenacity secondary.

The mod type has been pulled out from the bonus calculation because I think we should limit the scope of the rating to just the secondaries for now until I've come up with a better thorough way of judging the quality of the mods. (Think about the health sets that are used extensively with different combinations of stats or how do slot and primary stat align with the secondaries).

Other changes:
- Fraction of a star is now more precise.
- Fixed the inaccurate score of 4-dot mods and lower.