### PR TITLE
Added a tooltip to explain the order of priorities

### DIFF
--- a/src/containers/CharacterList/CharacterList.js
+++ b/src/containers/CharacterList/CharacterList.js
@@ -92,7 +92,7 @@ class CharacterList extends PureComponent {
     const draggable = this.props.draggable;
 
     const selectedPlan = target.name;
-    const priorityOrder = selectedPlan in defaultTargets ? defaultTargets[selectedPlan].priorityOrderStr() : null;
+    const priorityOrder = target.priorityOrderStr();
     const options = character.targets()
       .map(characterTarget => characterTarget.name)
       .filter(targetName => 'custom' !== targetName)
@@ -102,7 +102,9 @@ class CharacterList extends PureComponent {
           !defaultTargets[targetName].equals(
             character.optimizerSettings.targets.find(target => target.name === targetName)
           ) ? '*' : '';
-        const priorityOrder = defaultTargets[targetName].priorityOrderStr() || null;
+        const priorityOrder = (
+            character.optimizerSettings.targets.find(target => target.name === targetName) || defaultTargets[targetName]
+        ).priorityOrderStr() || null;
         return <option value={targetName} key={targetName} title={priorityOrder}>{changeIndicator}{targetName}</option>;
       });
 

--- a/src/containers/CharacterList/CharacterList.js
+++ b/src/containers/CharacterList/CharacterList.js
@@ -92,6 +92,7 @@ class CharacterList extends PureComponent {
     const draggable = this.props.draggable;
 
     const selectedPlan = target.name;
+    const priorityOrder = selectedPlan in defaultTargets ? defaultTargets[selectedPlan].priorityOrderStr() : null;
     const options = character.targets()
       .map(characterTarget => characterTarget.name)
       .filter(targetName => 'custom' !== targetName)
@@ -101,8 +102,8 @@ class CharacterList extends PureComponent {
           !defaultTargets[targetName].equals(
             character.optimizerSettings.targets.find(target => target.name === targetName)
           ) ? '*' : '';
-
-        return <option value={targetName} key={targetName}>{changeIndicator}{targetName}</option>;
+        const priorityOrder = defaultTargets[targetName].priorityOrderStr() || null;
+        return <option value={targetName} key={targetName} title={priorityOrder}>{changeIndicator}{targetName}</option>;
       });
 
     const onSelect = function (e) {
@@ -144,7 +145,7 @@ class CharacterList extends PureComponent {
         </div>
         <div className={'target'}>
           <label>Target:</label>
-          <Dropdown value={selectedPlan} onChange={onSelect.bind(this)}>
+          <Dropdown value={selectedPlan} onChange={onSelect.bind(this)} title={priorityOrder}>
             {options}
             <option value={'custom'}>Custom</option>
           </Dropdown>

--- a/src/domain/OptimizationPlan.js
+++ b/src/domain/OptimizationPlan.js
@@ -2,6 +2,7 @@
 
 import areObjectsEquivalent from "../utils/areObjectsEquivalent";
 import TargetStat from "./TargetStat";
+import Stat from "./Stat";
 
 /**
  * A class to represent the weights that should be applied to each potential stat that a mod can have when
@@ -346,6 +347,32 @@ class OptimizationPlan {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Generate the priority order string
+   *
+   * @returns {String} String representing the priority order
+   */
+  priorityOrderStr() {
+    // order name / value (not null)
+    const priorityOrder = Object.entries(this)
+      .filter(o => o[0].startsWith('raw') && o[1] > 0)  // Filter on "raw****" not null values
+      .sort(([,a],[,b]) => b-a)  // ordering by values
+      .map(o => [Stat.displayNames[o[0][3].toLowerCase() + o[0].substring(4)], o[1]]) // Get human-friendly name and values
+
+    // Add '>' or '='
+    let lastValue = 0;
+    let result = [];
+    for(const [name, value] of priorityOrder) {
+      if (lastValue) {
+        result.push(lastValue > value ? '>' : '=');
+      }
+      lastValue = value;
+      result.push(name);
+    }
+
+    return result.join(' ');
   }
 }
 


### PR DESCRIPTION
Added a tooltip to explain the order of priorities associated with a profile:

![tooltip](https://user-images.githubusercontent.com/207457/197597625-fc40d41b-a070-45aa-aa1f-f885eac3bad5.png)

