### PR TITLE
fix: add default parameters to TargetStat constructor

### DIFF
--- a/src/constants/characterSettings.js
+++ b/src/constants/characterSettings.js
@@ -561,7 +561,7 @@ const characterSettings = {
       new OptimizationPlan('PvP', 0, 0, 100, 100, 25, 0, 25, 0, 25, 0, 0, 0, 0, true),
       new OptimizationPlan('Iden Lead', 10, 10, 100, 100, 40, 0, 25, 0, 0, 0, 0, 0, 0, true),
       new OptimizationPlan('hSTR Phase 3', 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, true, {}, {},
-        [new TargetStat('Speed', 175, 179)]
+        [new TargetStat('Speed', '+', 175, 179)]
       )
     ],
     ['Troopers', 'Chex Mix']
@@ -842,7 +842,7 @@ const characterSettings = {
     [
       new OptimizationPlan('Crits', 0, 0, 100, 50, 25, 0, 25, 0, 100, 0, 0, 0, 0, true),
       new OptimizationPlan('hSTR Phase 3', 0, 0, 0, 100, 0, 0, 50, 0, 50, 0, 0, 0, 0, true, {}, {},
-        [new TargetStat('Speed', 170, 174)]
+        [new TargetStat('Speed', '+', 170, 174)]
       )
     ]
   ),
@@ -863,7 +863,7 @@ const characterSettings = {
       new OptimizationPlan('Slow Han', 0, 0, 0, 100, 25, 0, 50, 0, 0, 0, 0, 0, 0, true),
       new OptimizationPlan('Non-relic', 0, 0, 100, 100, 25, 0, 50, 0, 50, 0, 0, 0, 0, true),
       new OptimizationPlan('Chex Mix', 0, 0, 0, 100, 0, 0, 50, 0, 50, 0, 0, 0, 0, true, {}, {},
-        [new TargetStat('Speed', 170, 174)]
+        [new TargetStat('Speed', '+', 170, 174)]
       )
     ],
     ['Raid Han', 'rHan', 'OG Han', 'Zolo', 'Chex Mix', 'Titans']

--- a/src/domain/TargetStat.js
+++ b/src/domain/TargetStat.js
@@ -12,7 +12,7 @@ export default class TargetStat {
   optimizeForTarget;
 
 
-  constructor(stat, type, minimum, maximum, relativeCharacterId = null, optimizeForTarget = true) {
+  constructor(stat, type='+', minimum=0, maximum=0, relativeCharacterId = null, optimizeForTarget = true) {
     this.stat = stat;
     this.type = type;
     this.minimum = minimum;


### PR DESCRIPTION
In characterSettings TargetStat is initialized without an argument for the type. Without a character to compare to, it is not needed. Ex: new TargetStat('Speed', 170,174)
But the parameterlist has the type in the second position. So the 170 argument is assigned to type param, maximum argument gets assigned to the minimum param and maximum param is undefined. (Check for example Greedo's TargetStats to see this)

By adding default values to the constructor's signature this is avoided and we don't have to add arguments to the calls that wouldn't make sense.